### PR TITLE
fix: issue 122

### DIFF
--- a/Core/Core/Extensions/Notification.swift
+++ b/Core/Core/Extensions/Notification.swift
@@ -16,7 +16,6 @@ public extension Notification.Name {
     static let onAppUpgradeAccountSettingsTapped = Notification.Name("onAppUpgradeAccountSettingsTapped")
     static let onNewVersionAvaliable = Notification.Name("onNewVersionAvaliable")
     static let webviewReloadNotification = Notification.Name("webviewReloadNotification")
-    static let onBlockCompletion = Notification.Name("onBlockCompletion")
     static let shiftCourseDates = Notification.Name("shiftCourseDates")
     static let profileUpdated = Notification.Name("profileUpdated")
     static let getCourseDates = Notification.Name("getCourseDates")

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -967,6 +967,13 @@ public final class CourseContainerViewModel: BaseCourseViewModel {
             .sink { [weak self] _ in
                 guard let self = self else { return }
                 updateCourseProgress = true
+
+                if let id = courseStructure?.id {
+                    Task {
+                       await self.updateCourseIfNeeded(courseID: id)
+                    }
+                }
+
             }
             .store(in: &cancellables)
     }

--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -35,6 +35,7 @@ public protocol CourseRouter: BaseRouter {
     )
     
     func showCourseVerticalView(
+        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,
@@ -92,6 +93,7 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
     ) {}
     
     public func showCourseVerticalView(
+        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,

--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -36,7 +36,6 @@ public protocol CourseRouter: BaseRouter {
     )
     
     func showCourseVerticalView(
-        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,
@@ -94,7 +93,6 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
     ) {}
     
     public func showCourseVerticalView(
-        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,

--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Core
+import SwiftUI
 
 @MainActor
 public protocol CourseRouter: BaseRouter {
@@ -38,7 +39,7 @@ public protocol CourseRouter: BaseRouter {
         courseID: String,
         courseName: String,
         title: String,
-        chapters: [CourseChapter],
+        chapters: Binding<[CourseChapter]>,
         chapterIndex: Int,
         sequentialIndex: Int
     )
@@ -95,7 +96,7 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
         courseID: String,
         courseName: String,
         title: String,
-        chapters: [CourseChapter],
+        chapters: Binding<[CourseChapter]>,
         chapterIndex: Int,
         sequentialIndex: Int
     ) {}

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -106,7 +106,22 @@ public struct CourseOutlineView: View {
                                     if let course = isVideo
                                         ? viewModel.courseVideosStructure
                                         : viewModel.courseStructure {
-                                        
+
+                                        let courseBinding = Binding<CourseStructure>(
+                                               get: {
+                                                   isVideo
+                                                       ? viewModel.courseVideosStructure ?? course
+                                                       : viewModel.courseStructure ?? course
+                                               },
+                                               set: { newValue in
+                                                   if isVideo {
+                                                       viewModel.courseVideosStructure = newValue
+                                                   } else {
+                                                       viewModel.courseStructure = newValue
+                                                   }
+                                               }
+                                           )
+
                                         if !isVideo,
                                            let progress = course.courseProgress,
                                            progress.totalAssignmentsCount != 0 {
@@ -118,7 +133,7 @@ public struct CourseOutlineView: View {
                                         
                                         // MARK: - Sections
                                         CustomDisclosureGroup(
-                                            course: course,
+                                            course: courseBinding,
                                             proxy: proxy,
                                             viewModel: viewModel
                                         )
@@ -213,29 +228,8 @@ public struct CourseOutlineView: View {
                 )
             }
         }
-        .onReceive(
-            NotificationCenter.default.publisher(
-                for: .onBlockCompletion
-            )
-        ) { notification in
-            guard let userInfo = notification.userInfo,
-                  let chapterID = userInfo["chapterID"] as? String,
-                  let sequentialID = userInfo["sequentialID"] as? String,
-                  let verticalID = userInfo["verticalID"] as? String,
-                  let blockID = userInfo["blockID"] as? String else {
-                return
-            }
-            Task {
-                await viewModel.completeBlock(
-                    chapterID: chapterID,
-                    sequentialID: sequentialID,
-                    verticalID: verticalID,
-                    blockID: blockID
-                )
-            }
-        }
     }
-    
+
     @ViewBuilder
     private func downloadQualityBars(proxy: GeometryProxy) -> some View {
         if let courseVideosStructure = viewModel.courseVideosStructure,

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -213,29 +213,8 @@ public struct CourseOutlineView: View {
                 )
             }
         }
-        .onReceive(
-            NotificationCenter.default.publisher(
-                for: .onBlockCompletion
-            )
-        ) { notification in
-            guard let userInfo = notification.userInfo,
-                  let chapterID = userInfo["chapterID"] as? String,
-                  let sequentialID = userInfo["sequentialID"] as? String,
-                  let verticalID = userInfo["verticalID"] as? String,
-                  let blockID = userInfo["blockID"] as? String else {
-                return
-            }
-            Task {
-                await viewModel.completeBlock(
-                    chapterID: chapterID,
-                    sequentialID: sequentialID,
-                    verticalID: verticalID,
-                    blockID: blockID
-                )
-            }
-        }
     }
-    
+
     @ViewBuilder
     private func downloadQualityBars(proxy: GeometryProxy) -> some View {
         if let courseVideosStructure = viewModel.courseVideosStructure,

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
@@ -176,6 +176,7 @@ struct CourseVerticalView_Previews: PreviewProvider {
         ]
         
         let viewModel = CourseVerticalViewModel(
+            parentVM: nil,
             chapters: chapters,
             chapterIndex: 0,
             sequentialIndex: 0,

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
@@ -134,13 +134,16 @@ public struct CourseVerticalView: View {
             Theme.Colors.background
                 .ignoresSafeArea()
         )
+        .onAppear {
+            viewModel.refreshVerticals()
+        }
     }
 }
 
 #if DEBUG
 struct CourseVerticalView_Previews: PreviewProvider {
     static var previews: some View {
-        let chapters = [
+        @State var chapters = [
             CourseChapter(
                 blockId: "1",
                 id: "1",
@@ -176,7 +179,7 @@ struct CourseVerticalView_Previews: PreviewProvider {
         ]
         
         let viewModel = CourseVerticalViewModel(
-            chapters: chapters,
+            chapters: $chapters,
             chapterIndex: 0,
             sequentialIndex: 0,
             router: CourseRouterMock(),

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
@@ -9,7 +9,11 @@ import SwiftUI
 import Core
 import OEXFoundation
 
+@MainActor
 public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendable {
+
+    private let parentVM: CourseContainerViewModel?
+
     let router: CourseRouter
     let analytics: CourseAnalytics
     let connectivity: ConnectivityProtocol
@@ -28,6 +32,7 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
     }
     
     public init(
+        parentVM: CourseContainerViewModel?,
         chapters: [CourseChapter],
         chapterIndex: Int,
         sequentialIndex: Int,
@@ -35,13 +40,22 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
         analytics: CourseAnalytics,
         connectivity: ConnectivityProtocol
     ) {
+        self.parentVM = parentVM
         self.chapters = chapters
         self.chapterIndex = chapterIndex
         self.sequentialIndex = sequentialIndex
         self.router = router
         self.analytics = analytics
         self.connectivity = connectivity
-        self.verticals = chapters[chapterIndex].childs[sequentialIndex].childs
+
+        self.verticals = parentVM?.courseStructure?.childs[chapterIndex].childs[sequentialIndex].childs ?? []
+
+        parentVM?.$courseStructure
+            .compactMap { $0?.childs[chapterIndex]
+                    .childs[sequentialIndex]
+                .childs }
+            .assign(to: &$verticals)
+
     }
     
     func trackVerticalClicked(

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
@@ -12,8 +12,6 @@ import OEXFoundation
 @MainActor
 public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendable {
 
-    private let parentVM: CourseContainerViewModel?
-
     let router: CourseRouter
     let analytics: CourseAnalytics
     let connectivity: ConnectivityProtocol
@@ -46,7 +44,6 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
           self.analytics = analytics
           self.connectivity = connectivity
 
-          // безопасная инициализация verticals
           if chapters.wrappedValue.indices.contains(chapterIndex),
              chapters.wrappedValue[chapterIndex].childs.indices.contains(sequentialIndex) {
               self.verticals = chapters.wrappedValue[chapterIndex].childs[sequentialIndex].childs
@@ -54,6 +51,7 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
               self.verticals = []
           }
       }
+
     func trackVerticalClicked(
         courseId: String,
         courseName: String,

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalViewModel.swift
@@ -15,7 +15,7 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
     let connectivity: ConnectivityProtocol
     @Published var verticals: [CourseVertical]
     @Published var showError: Bool = false
-    let chapters: [CourseChapter]
+    @Binding var chapters: [CourseChapter]
     let chapterIndex: Int
     let sequentialIndex: Int
     
@@ -26,24 +26,30 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
             }
         }
     }
-    
+
     public init(
-        chapters: [CourseChapter],
-        chapterIndex: Int,
-        sequentialIndex: Int,
-        router: CourseRouter,
-        analytics: CourseAnalytics,
-        connectivity: ConnectivityProtocol
-    ) {
-        self.chapters = chapters
-        self.chapterIndex = chapterIndex
-        self.sequentialIndex = sequentialIndex
-        self.router = router
-        self.analytics = analytics
-        self.connectivity = connectivity
-        self.verticals = chapters[chapterIndex].childs[sequentialIndex].childs
-    }
-    
+          chapters: Binding<[CourseChapter]>,
+          chapterIndex: Int,
+          sequentialIndex: Int,
+          router: CourseRouter,
+          analytics: CourseAnalytics,
+          connectivity: ConnectivityProtocol
+      ) {
+          self._chapters = chapters
+          self.chapterIndex = chapterIndex
+          self.sequentialIndex = sequentialIndex
+          self.router = router
+          self.analytics = analytics
+          self.connectivity = connectivity
+
+          // безопасная инициализация verticals
+          if chapters.wrappedValue.indices.contains(chapterIndex),
+             chapters.wrappedValue[chapterIndex].childs.indices.contains(sequentialIndex) {
+              self.verticals = chapters.wrappedValue[chapterIndex].childs[sequentialIndex].childs
+          } else {
+              self.verticals = []
+          }
+      }
     func trackVerticalClicked(
         courseId: String,
         courseName: String,
@@ -56,4 +62,11 @@ public final class CourseVerticalViewModel: ObservableObject, @unchecked Sendabl
             blockName: vertical.displayName
         )
     }
+
+    public func refreshVerticals() {
+          if chapters.indices.contains(chapterIndex),
+             chapters[chapterIndex].childs.indices.contains(sequentialIndex) {
+              verticals = chapters[chapterIndex].childs[sequentialIndex].childs
+          }
+      }
 }

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -13,12 +13,16 @@ struct CustomDisclosureGroup: View {
     @State private var expandedSections: [String: Bool] = [:]
     
     private let proxy: GeometryProxy
-    private let course: CourseStructure
+    @Binding var course: CourseStructure
     private let viewModel: CourseContainerViewModel
     private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
-    init(course: CourseStructure, proxy: GeometryProxy, viewModel: CourseContainerViewModel) {
-        self.course = course
+    init(
+        course: Binding<CourseStructure>,
+        proxy: GeometryProxy,
+        viewModel: CourseContainerViewModel
+    ) {
+        self._course = course
         self.proxy = proxy
         self.viewModel = viewModel
     }
@@ -100,7 +104,7 @@ struct CustomDisclosureGroup: View {
                                                         courseID: viewModel.courseStructure?.id ?? "",
                                                         courseName: viewModel.courseStructure?.displayName ?? "",
                                                         title: sequential.displayName,
-                                                        chapters: course.childs,
+                                                        chapters: $course.childs,
                                                         chapterIndex: chapterIndex,
                                                         sequentialIndex: sequentialIndex
                                                     )
@@ -392,7 +396,22 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                 ]
             )
         ]
-        
+
+        @State var course = CourseStructure(
+            id: "Id",
+            graded: false,
+            completion: 0,
+            viewYouTubeUrl: "",
+            encodedVideo: "",
+            displayName: "Course",
+            childs: sampleCourseChapters,
+            media: CourseMedia.init(image: CourseImage(raw: "", small: "", large: "")),
+            certificate: nil,
+            org: "org",
+            isSelfPaced: false,
+            courseProgress: nil
+        )
+
         let viewModel = CourseContainerViewModel(
             interactor: CourseInteractor.mock,
             authInteractor: AuthInteractor.mock,
@@ -425,20 +444,7 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
         return GeometryReader { proxy in
             ScrollView {
                 CustomDisclosureGroup(
-                    course: CourseStructure(
-                        id: "Id",
-                        graded: false,
-                        completion: 0,
-                        viewYouTubeUrl: "",
-                        encodedVideo: "",
-                        displayName: "Course",
-                        childs: sampleCourseChapters,
-                        media: CourseMedia.init(image: CourseImage(raw: "", small: "", large: "")),
-                        certificate: nil,
-                        org: "org",
-                        isSelfPaced: false,
-                        courseProgress: nil
-                    ),
+                    course: $course,
                     proxy: proxy,
                     viewModel: viewModel
                 )

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -97,6 +97,7 @@ struct CustomDisclosureGroup: View {
                                                     )
                                                 } else {
                                                     viewModel.router.showCourseVerticalView(
+                                                        parentVM: viewModel,
                                                         courseID: viewModel.courseStructure?.id ?? "",
                                                         courseName: viewModel.courseStructure?.displayName ?? "",
                                                         title: sequential.displayName,

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -11,9 +11,9 @@ import Theme
 
 struct CustomDisclosureGroup: View {
     @State private var expandedSections: [String: Bool] = [:]
-    
-    private let proxy: GeometryProxy
     @Binding var course: CourseStructure
+
+    private let proxy: GeometryProxy
     private let viewModel: CourseContainerViewModel
     private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
@@ -101,7 +101,6 @@ struct CustomDisclosureGroup: View {
                                                     )
                                                 } else {
                                                     viewModel.router.showCourseVerticalView(
-                                                        parentVM: viewModel,
                                                         courseID: viewModel.courseStructure?.id ?? "",
                                                         courseName: viewModel.courseStructure?.displayName ?? "",
                                                         title: sequential.displayName,

--- a/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
@@ -352,7 +352,7 @@ public final class CourseUnitViewModel: ObservableObject {
     private func setBlockCompletionForSelectedLesson() {
         verticals[verticalIndex].childs[index].completion = 1.0
         NotificationCenter.default.post(
-            name: .onBlockCompletion,
+            name: .onblockCompletionRequested,
             object: nil,
             userInfo: [
                 "chapterID": chapters[chapterIndex].id,

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -363,6 +363,7 @@ class ScreenAssembly: Assembly {
         ) { @MainActor r in
             CourseDownloadHelper(courseStructure: nil, manager: r.resolve(DownloadManagerProtocol.self)!)
         }
+        
         container.register(CourseVerticalViewModel.self) { @MainActor r, chapters, chapterIndex, sequentialIndex in
             CourseVerticalViewModel(
                 chapters: chapters,

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -366,7 +366,6 @@ class ScreenAssembly: Assembly {
         
         container.register(CourseVerticalViewModel.self) { @MainActor r, chapters, chapterIndex, sequentialIndex in
             CourseVerticalViewModel(
-                parentVM: parentVM,
                 chapters: chapters,
                 chapterIndex: chapterIndex,
                 sequentialIndex: sequentialIndex,

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -363,8 +363,13 @@ class ScreenAssembly: Assembly {
         ) { @MainActor r in
             CourseDownloadHelper(courseStructure: nil, manager: r.resolve(DownloadManagerProtocol.self)!)
         }
-        container.register(CourseVerticalViewModel.self) { @MainActor r, chapters, chapterIndex, sequentialIndex in
+        container.register(CourseVerticalViewModel.self) { @MainActor r,
+            parentVM,
+            chapters,
+            chapterIndex,
+            sequentialIndex in
             CourseVerticalViewModel(
+                parentVM: parentVM,
                 chapters: chapters,
                 chapterIndex: chapterIndex,
                 sequentialIndex: sequentialIndex,

--- a/OpenEdX/Managers/PipManager.swift
+++ b/OpenEdX/Managers/PipManager.swift
@@ -133,7 +133,6 @@ public final class PipManager: PipManagerProtocol {
         
         if let data = VerticalData.dataFor(blockId: holder.blockID, in: courseStructure.childs) {
             return router.getVerticalController(
-                parentVM: nil,
                 courseID: holder.courseID,
                 courseName: courseStructure.displayName,
                 title: courseStructure.childs[data.chapterIndex].childs[data.sequentialIndex].displayName,

--- a/OpenEdX/Managers/PipManager.swift
+++ b/OpenEdX/Managers/PipManager.swift
@@ -133,6 +133,7 @@ public final class PipManager: PipManagerProtocol {
         
         if let data = VerticalData.dataFor(blockId: holder.blockID, in: courseStructure.childs) {
             return router.getVerticalController(
+                parentVM: nil,
                 courseID: holder.courseID,
                 courseName: courseStructure.displayName,
                 title: courseStructure.childs[data.chapterIndex].childs[data.sequentialIndex].displayName,

--- a/OpenEdX/Managers/PipManager.swift
+++ b/OpenEdX/Managers/PipManager.swift
@@ -136,7 +136,7 @@ public final class PipManager: PipManagerProtocol {
                 courseID: holder.courseID,
                 courseName: courseStructure.displayName,
                 title: courseStructure.childs[data.chapterIndex].childs[data.sequentialIndex].displayName,
-                chapters: courseStructure.childs,
+                chapters: .constant(courseStructure.childs),
                 chapterIndex: data.chapterIndex,
                 sequentialIndex: data.sequentialIndex
             )

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -338,7 +338,6 @@ public class Router: AuthorizationRouter,
         sequentialIndex: Int
     ) {
         let controller = getVerticalController(
-            parentVM: parentVM,
             courseID: courseID,
             courseName: courseName,
             title: title,
@@ -350,7 +349,6 @@ public class Router: AuthorizationRouter,
     }
 
     public func getVerticalController(
-        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,
@@ -359,8 +357,7 @@ public class Router: AuthorizationRouter,
         sequentialIndex: Int
     ) -> UIHostingController<CourseVerticalView> {
         let viewModel = Container.shared.resolve(
-            CourseVerticalViewModel.self,
-            arguments: parentVM,
+            CourseVerticalViewModel.self, arguments:
             chapters,
             chapterIndex,
             sequentialIndex
@@ -625,7 +622,6 @@ public class Router: AuthorizationRouter,
             controllers.append(contentsOf: [controllerUnit])
         } else {
             let controllerVertical = getVerticalController(
-                parentVM: nil,
                 courseID: courseID,
                 courseName: courseName,
                 title: chapters[chapterIndex].childs[sequentialIndex].displayName,

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -328,16 +328,16 @@ public class Router: AuthorizationRouter,
         let controller = UIHostingController(rootView: view)
         navigationController.pushFade(viewController: controller)
     }
-    
-    public func showCourseVerticalView(
-        courseID: String,
-        courseName: String,
-        title: String,
-        chapters: [CourseChapter],
-        chapterIndex: Int,
-        sequentialIndex: Int
-    ) {
+
+    public func showCourseVerticalView(parentVM: Course.CourseContainerViewModel?,
+                                       courseID: String,
+                                       courseName: String,
+                                       title: String,
+                                       chapters: [Core.CourseChapter],
+                                       chapterIndex: Int,
+                                       sequentialIndex: Int) {
         let controller = getVerticalController(
+            parentVM: parentVM,
             courseID: courseID,
             courseName: courseName,
             title: title,
@@ -347,8 +347,9 @@ public class Router: AuthorizationRouter,
         )
         navigationController.pushViewController(controller, animated: true)
     }
-    
+
     public func getVerticalController(
+        parentVM: CourseContainerViewModel?,
         courseID: String,
         courseName: String,
         title: String,
@@ -358,7 +359,8 @@ public class Router: AuthorizationRouter,
     ) -> UIHostingController<CourseVerticalView> {
         let viewModel = Container.shared.resolve(
             CourseVerticalViewModel.self,
-            arguments: chapters,
+            arguments: parentVM,
+            chapters,
             chapterIndex,
             sequentialIndex
         )!
@@ -622,6 +624,7 @@ public class Router: AuthorizationRouter,
             controllers.append(contentsOf: [controllerUnit])
         } else {
             let controllerVertical = getVerticalController(
+                parentVM: nil,
                 courseID: courseID,
                 courseName: courseName,
                 title: chapters[chapterIndex].childs[sequentialIndex].displayName,

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -333,7 +333,7 @@ public class Router: AuthorizationRouter,
         courseID: String,
         courseName: String,
         title: String,
-        chapters: [CourseChapter],
+        chapters: Binding<[CourseChapter]>,
         chapterIndex: Int,
         sequentialIndex: Int
     ) {
@@ -352,7 +352,7 @@ public class Router: AuthorizationRouter,
         courseID: String,
         courseName: String,
         title: String,
-        chapters: [CourseChapter],
+        chapters: Binding<[CourseChapter]>,
         chapterIndex: Int,
         sequentialIndex: Int
     ) -> UIHostingController<CourseVerticalView> {
@@ -625,7 +625,7 @@ public class Router: AuthorizationRouter,
                 courseID: courseID,
                 courseName: courseName,
                 title: chapters[chapterIndex].childs[sequentialIndex].displayName,
-                chapters: chapters,
+                chapters: .constant(chapters),
                 chapterIndex: chapterIndex,
                 sequentialIndex: sequentialIndex
             )


### PR DESCRIPTION
Adress issue https://github.com/openedx/openedx-app-ios/issues/122

Problem:
When the user completed an assignment and navigated back to the modules or subsections, the update was not triggered automatically. A manual pull-to-refresh was required.

Solution:
Now, as soon as the user completes an assignment, we send a request to update the course so that when navigating back, the user sees the completed modules and subsections.


Examples:

Old without auto refresh
https://github.com/user-attachments/assets/e1cf8141-d947-4c53-b597-d9704aed2dfb

New with auto refresh
https://github.com/user-attachments/assets/b37510e7-9c80-4013-b33a-3e1b9ed5d6da


